### PR TITLE
support already created backup region tables and fix readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+.idea
+
 # Runtime data
 pids
 *.pid

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
-# serverless-create-global-dynamodb-table
+# serverless-create-global-dynamodb-table-2
 [![serverless](http://public.serverless.com/badges/v3.svg)](http://www.serverless.com)
+
+This is a fork of serverless-create-global-dynamodb-table with additional bugfixes.
 
 A [serverless](http://www.serverless.com) plugin to _automatically_ creates dynamodb global table(s).
 The plugin will create the dynamodb table in the specified region(s) and setup sync between  primary and other table(s).
 
 ## Install
 
-`npm install --save-dev serverless-create-global-dynamodb-table`
+`npm install --save-dev serverless-create-global-dynamodb-table-2`
 
 Add the plugin to your `serverless.yml` file:
 
 ```yaml
 plugins:
-  - serverless-create-global-dynamodb-table
+  - serverless-create-global-dynamodb-table-2
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ custom:
     - regions: # list of regions in which you want to set up global tables
       - region-1
       - region-2
-    - tableKey: 'TABLE_KEY' # Cloudformation output key name if the table is created as part of same serverless service
-    - tableName: 'TABLE_NAME' # if table is not part of the service then specify the table name. If tableKey param exists then tableName is ignored.
-    - tags: # List of tags that needs to applied to the new table (optional)
+      tableKey: 'TABLE_KEY' # Cloudformation output key name if the table is created as part of same serverless service
+      tableName: 'TABLE_NAME' # if table is not part of the service then specify the table name. If tableKey param exists then tableName is ignored.
+      tags: # List of tags that needs to applied to the new table (optional)
       - Key: tag-key
         Value: tag-value
       - Key: tag-key-2

--- a/index.js
+++ b/index.js
@@ -16,6 +16,19 @@ const createAndTagTable = async function createAndTagTable(region, tableName, se
     region,
   })
   try {
+
+    try {
+      await dynamodb.describeTable({TableName: tableName}).promise();
+      cli.consoleLog(`CreateGlobalTable: ${chalk.yellow('Backup region table already exists in ${region}. Skipping creation...')}`);
+      return
+    }
+    catch (e) {
+      if (e.code !== 'ResourceNotFoundException') {
+        throw e
+      }
+      cli.consoleLog(`CreateGlobalTable: ${chalk.yellow('Backup region table doesnt exist yet in ${region}. Creating...')}`)
+    }
+
     const createResp = await dynamodb.createTable(setting).promise()
     cli.consoleLog(`CreateGlobalTable: ${chalk.yellow(`Created new table ${tableName} in ${region} region...`)}`);
     const { TableArn } = createResp.TableDescription;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "serverless-create-global-dynamodb-table",
+  "name": "serverless-create-global-dynamodb-table-2",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "serverless-create-global-dynamodb-table",
-  "version": "1.1.0",
-  "description": "serverless plugin that would create global dynamodb tables for specified tables",
+  "name": "serverless-create-global-dynamodb-table-2",
+  "version": "1.0.1",
+  "description": "serverless plugin that creates global dynamodb tables",
   "main": "index.js",
   "scripts": {
     "precommit": "eslint .",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rrahul963/serverless-create-global-dynamodb-table.git"
+    "url": "git+https://github.com/johndww/serverless-create-global-dynamodb-table.git"
   },
   "keywords": [
     "serverless",
@@ -17,12 +17,12 @@
     "table",
     "dynamodb"
   ],
-  "author": "rahul.tulsian87@gmail.com",
+  "author": "delive@gmail.com",
   "license": "Apache 2.0",
   "bugs": {
-    "url": "https://github.com/rrahul963/serverless-create-global-dynamodb-table/issues"
+    "url": "https://github.com/johndww/serverless-create-global-dynamodb-table/issues"
   },
-  "homepage": "https://github.com/rrahul963/serverless-create-global-dynamodb-table#readme",
+  "homepage": "https://github.com/johndww/serverless-create-global-dynamodb-table#readme",
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",


### PR DESCRIPTION
The readme didn't seem correct to support multiple global tables. Also, the plugin was brittle in if the backup region creates succeeded, but the global table linkage failed, then the deployment isn't re-runnable because it fails with a duplicate table re-creating the backup region tables.