### PR TITLE
support already created backup tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+.idea
+
 # Runtime data
 pids
 *.pid


### PR DESCRIPTION
should allow partially failed deploys to work on a second deploy