### PR TITLE
Support PAY_PER_REQUEST billing mode fully

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-create-global-dynamodb-table",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-create-global-dynamodb-table",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "serverless plugin that would create global dynamodb tables for specified tables",
   "main": "src/index.js",
   "scripts": {

--- a/src/helper.js
+++ b/src/helper.js
@@ -262,7 +262,6 @@ const createGlobalTable = async function createGlobalTable(
     const createTableParams = {
       AttributeDefinitions: tableDef.Table.AttributeDefinitions,
       KeySchema: tableDef.Table.KeySchema,
-      ProvisionedThroughput: { ReadCapacityUnits, WriteCapacityUnits },
       TableName: tableName,
       StreamSpecification: {
         StreamEnabled: true,
@@ -271,6 +270,13 @@ const createGlobalTable = async function createGlobalTable(
       GlobalSecondaryIndexes: globalSecondaryIndexes.length ? globalSecondaryIndexes : undefined,
       LocalSecondaryIndexes: localSecondaryIndexes.length ? localSecondaryIndexes : undefined
     };
+
+    const billingModeSummary = tableDef.Table.BillingModeSummary;
+    if (billingModeSummary && billingModeSummary.BillingMode === 'PAY_PER_REQUEST') {
+      createTableParams.BillingMode = 'PAY_PER_REQUEST';
+    } else {
+      createTableParams.ProvisionedThroughput = { ReadCapacityUnits, WriteCapacityUnits }
+    }
 
     const tags = await dynamodb.listTagsOfResource({ ResourceArn: tableDef.Table.TableArn }).promise();
     createTableParams.Tags = tags.Tags;


### PR DESCRIPTION
When using tables which are billed with "PAY_PER_REQUEST", the returned write/read capacity units is 0, which is not a valid unit to use when creating a table. write/read capacity units are not required for tables which are billed "PAY_PER_REQUEST".