### PR TITLE
Fix createTable() with GlobalSecondaryIndexes

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -258,7 +258,12 @@ const createGlobalTable = async function createGlobalTable(
           IndexName: gsi.IndexName,
           KeySchema: gsi.KeySchema,
           Projection: gsi.Projection,
-          ProvisionedThroughput: gsi.ProvisionedThroughput
+          ...((gsi.ProvisionedThroughput.ReadCapacityUnits !== 0 || gsi.ProvisionedThroughput.WriteCapacityUnits !== 0) && {
+            ProvisionedThroughput: {
+              ReadCapacityUnits: gsi.ProvisionedThroughput.ReadCapacityUnits,
+              WriteCapacityUnits: gsi.ProvisionedThroughput.WriteCapacityUnits,
+            },
+          }),
         })
       })
     }


### PR DESCRIPTION
The plugin runs into errors when creating tables with GlobalSecondaryIndexes defined. This is because the AWS DynamoDB API describeTable() returns additional properties in the GSI ProvisionedThroughput object that are not expected when performing a createTable(). These extra properties are defined here https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ProvisionedThroughputDescription.html (eg. NumberOfDecreasesToday)

This fixes the issue noted in https://github.com/rrahul963/serverless-create-global-dynamodb-table/issues/18.

There is a conditional to add the ProvisionedThroughput property to the GSI because an empty object or undefined would throw and error since if this property exists then the API expects the Read/WriteCapacityUnits to be >=1 which doesn't handles cases where this property isn't used in a GSI and the Billing Mode is PAY_PER_REQUEST.